### PR TITLE
fix: fix spotify redirect in prod

### DIFF
--- a/frontend/src/components/admin/AdminRoomView/AdminRoomView.js
+++ b/frontend/src/components/admin/AdminRoomView/AdminRoomView.js
@@ -244,7 +244,7 @@ function AdminRoomView() {
   // Fonctions de gestion de Spotify
   const handleConnectSpotify = () => {
     localStorage.setItem('spotify_redirect', window.location.pathname + window.location.search);
-    authenticateSpotify();
+    authenticateSpotify(roomCode);
   };
 
   const handleDisconnectSpotify = async () => {

--- a/frontend/src/services/api/spotifyService.js
+++ b/frontend/src/services/api/spotifyService.js
@@ -12,12 +12,12 @@ const getAuthHeaders = () => {
 };
 
 // Nouvelle méthode d'authentification qui redirige vers l'endpoint backend
-export const authenticateSpotify = () => {
-  const roomCode = new URLSearchParams(window.location.search).get('roomCode');
+export const authenticateSpotify = (roomCode) => {
+  const roomCodeToUse = roomCode || new URLSearchParams(window.location.search).get('roomCode');
   localStorage.setItem('spotify_redirect', window.location.pathname + window.location.search);
   
   // Récupérer l'URL d'authentification du backend
-  fetch(`${BASE_URL}/api/spotify/auth-url/${roomCode}`, {
+  fetch(`${BASE_URL}/api/spotify/auth-url/${roomCodeToUse}`, {
     headers: getAuthHeaders()
   })
     .then(response => response.json())


### PR DESCRIPTION
# Proposition de Pull Request

**Description**  
Dans la fonction handleConnectSpotify() du composant AdminRoomView.js, vous sauvegardez bien le chemin de redirection incluant le roomCode dans le localStorage, mais il y a un problème avec la fonction authenticateSpotify() importée depuis spotifyService.js.

Selon le code visible dans votre projet, la fonction authenticateSpotify() tente de récupérer le paramètre roomCode à partir de l'URL, mais elle ne reçoit pas explicitement ce paramètre comme argument. Modifier la fonction handleConnectSpotify() pour passer explicitement le roomCode.


**Problème associé (issue)**  
/
