### PR TITLE
chore: fix pause button rendering with backend in AdminRoomView

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,9 +7,9 @@
     },
     "dependencies": {
         "cors": "^2.8.5",
-        "dotenv": "^16.5.0",
+        "dotenv": "^17.2.0",
         "express": "^5.1.0",
-        "redis": "^5.5.6",
+        "redis": "^5.6.0",
         "socket.io": "^4.8.1",
         "spotify-web-api-node": "^5.0.2"
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
         "postcss": "^8.5.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2",
+        "react-router-dom": "^7.6.3",
         "react-toastify": "^11.0.5",
         "socket.io-client": "^4.8.1",
         "spotify-web-api-node": "^5.0.2"
@@ -28,9 +28,9 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@vitejs/plugin-react": "^4.5.2",
-        "knip": "^5.61.2",
-        "vite": "^6.3.5",
+        "@vitejs/plugin-react": "^4.6.0",
+        "knip": "^5.61.3",
+        "vite": "^7.0.4",
         "vite-plugin-svgr": "^4.3.0"
     }
 }

--- a/frontend/src/components/admin/AdminRoomView/AdminRoomView.jsx
+++ b/frontend/src/components/admin/AdminRoomView/AdminRoomView.jsx
@@ -152,7 +152,10 @@ function AdminRoomView() {
       setPlayers(newPlayers);
     };
     
-    const handleGamePaused = (pausedState) => {
+    const handleGamePaused = (data) => {
+      console.log("[AdminRoomView] Événement game_paused reçu:", data);
+      // ✅ CORRECTION : Le serveur envoie { paused: boolean }, pas un boolean direct
+      const pausedState = data.paused;
       console.log("[AdminRoomView] État pause mis à jour:", pausedState);
       setPaused(pausedState);
     };
@@ -703,24 +706,22 @@ const handleKick = async (playerId) => {
         console.log(`Tentative de ${paused ? 'reprise' : 'pause'} du jeu`);
         const newPauseState = !paused;
         
-        // Mettre à jour l'état local d'abord pour une réponse UI immédiate
-        setPaused(newPauseState);
+        // ❌ NE PAS mettre à jour l'état local immédiatement
+        // setPaused(newPauseState);
         
         // Envoyer la commande au serveur
         const response = await togglePause(roomCode, newPauseState);
         
         if (response && response.error) {
           console.error(`Erreur lors du changement de pause:`, response.error);
-          // Restaurer l'état précédent en cas d'erreur
-          setPaused(paused);
           alert(`Erreur: ${response.error}`);
         } else {
           console.log(`Jeu ${newPauseState ? 'en pause' : 'repris'} avec succès`);
+          // ✅ L'état sera mis à jour via l'événement 'game_paused' du serveur
         }
       } catch (error) {
         console.error("Exception lors du toggle pause:", error);
-        // Restaurer l'état précédent en cas d'erreur
-        setPaused(paused);
+        alert(`Erreur: ${error.message}`);
       }
     }
   };

--- a/frontend/src/pages/Changelog/Changelog.jsx
+++ b/frontend/src/pages/Changelog/Changelog.jsx
@@ -11,6 +11,18 @@ function Changelog() {
   // Données du changelog - vous pouvez les externaliser dans un fichier JSON plus tard
   const changelogEntries = [
     {
+      version: "2.2.3",
+      date: "2025-07-12",
+      type: "patch",
+      title: "Corrections gestion pause côté Admin",
+      changes: [
+        {
+          type: "fix",
+          text: "Admin : Correction de la possibilité de mettre en pause ou de reprendre la partie depuis le panel d'administration"
+        }
+      ]
+    },
+    {
       version: "2.2.2",
       date: "2025-07-05",
       type: "patch",


### PR DESCRIPTION
This pull request includes dependency updates and fixes for the admin panel's pause functionality. The most notable changes include upgrading several dependencies in both the backend and frontend, correcting the handling of the game pause state in the admin panel, and documenting the fixes in the changelog.

### Dependency Updates:
* [`backend/package.json`](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L10-R12): Updated `dotenv` to `^17.2.0` and `redis` to `^5.6.0`.
* [`frontend/package.json`](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L19-R19): Updated `react-router-dom` to `^7.6.3`, `@vitejs/plugin-react` to `^4.6.0`, `knip` to `^5.61.3`, and `vite` to `^7.0.4`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L19-R19) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L31-R33)

### Admin Panel Fixes:
* [`frontend/src/components/admin/AdminRoomView/AdminRoomView.jsx`](diffhunk://#diff-4e00caee65be54f75df01680863270df8a94bc5acb88c9f97b9799997a680780L155-R158): Fixed the `handleGamePaused` function to correctly process the server's `game_paused` event, which now sends an object with a `paused` property instead of a boolean directly.
* [`frontend/src/components/admin/AdminRoomView/AdminRoomView.jsx`](diffhunk://#diff-4e00caee65be54f75df01680863270df8a94bc5acb88c9f97b9799997a680780L706-R724): Updated the `handleKick` function to avoid prematurely updating the local pause state, ensuring the state is updated only via the server's `game_paused` event.

### Documentation:
* [`frontend/src/pages/Changelog/Changelog.jsx`](diffhunk://#diff-a483155dc6aeff37783e2b4633d6cf9db0567b99c5039eb7ac76af29b073ababR13-R24): Added a new changelog entry for version `2.2.3`, documenting the fixes related to pause functionality in the admin panel.