### PR TITLE
chore: fix spotify auto refresh token

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,9 +7,9 @@
     },
     "dependencies": {
         "cors": "^2.8.5",
-        "dotenv": "^17.2.0",
+        "dotenv": "^17.2.1",
         "express": "^5.1.0",
-        "redis": "^5.6.0",
+        "redis": "^5.7.0",
         "socket.io": "^4.8.1",
         "spotify-web-api-node": "^5.0.2"
     }

--- a/backend/src/controllers/spotifyController.js
+++ b/backend/src/controllers/spotifyController.js
@@ -36,12 +36,13 @@ async function handleCallback(req, res) {
     
     // Échanger le code contre des tokens
     const data = await spotifyApi.authorizationCodeGrant(code);
-    const { access_token, refresh_token } = data.body;
+    const { access_token, refresh_token, expires_in } = data.body;
     
     // Stocker les tokens pour cette salle
     await spotifyService.storeTokenForRoom(roomCode, { // Assurez-vous que c'est await si storeTokenForRoom est async
       accessToken: access_token,
-      RefreshToken: refresh_token
+      refreshToken: refresh_token,  // 🔧 CORRIGÉ: refreshToken (minuscule) au lieu de RefreshToken
+      expiresIn: expires_in || 3600 // 🔧 AJOUT: Inclure la durée d'expiration
     });
 
     // Mettre à jour l'option de la salle pour indiquer que Spotify est activé

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,12 +11,12 @@
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
         "autoprefixer": "^10.4.21",
-        "axios": "^1.10.0",
+        "axios": "^1.11.0",
         "bootstrap": "^5.3.7",
         "postcss": "^8.5.6",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.7.1",
         "react-toastify": "^11.0.5",
         "socket.io-client": "^4.8.1",
         "spotify-web-api-node": "^5.0.2"
@@ -28,9 +28,9 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@vitejs/plugin-react": "^4.6.0",
-        "knip": "^5.61.3",
-        "vite": "^7.0.4",
+        "@vitejs/plugin-react": "^4.7.0",
+        "knip": "^5.62.0",
+        "vite": "^7.0.6",
         "vite-plugin-svgr": "^4.3.0"
     }
 }

--- a/frontend/src/pages/Changelog/Changelog.jsx
+++ b/frontend/src/pages/Changelog/Changelog.jsx
@@ -11,6 +11,18 @@ function Changelog() {
   // Données du changelog - vous pouvez les externaliser dans un fichier JSON plus tard
   const changelogEntries = [
     {
+      version: "2.2.4",
+      date: "2025-08-05",
+      type: "patch",
+      title: "Correction gestion Spotify",
+      changes: [
+        {
+          type: "fix",
+          text: "Admin : Correction du rafraichissement du jeton Spotify pour éviter les erreurs de connexion passé 1h de jeu"
+        }
+      ]
+    },
+    {
       version: "2.2.3",
       date: "2025-07-12",
       type: "patch",

--- a/frontend/src/services/api/spotifyService.js
+++ b/frontend/src/services/api/spotifyService.js
@@ -29,11 +29,6 @@ export const authenticateSpotify = (roomCode) => {
     .catch(error => console.error('Erreur lors de la récupération de l\'URL d\'authentification:', error));
 };
 
-// Stockage du token reçu du serveur d'autorisation Spotify
-export const storeSpotifyToken = (token) => {
-  localStorage.setItem('spotify_token', token);
-};
-
 // Fonction utilitaire pour les requêtes Spotify
 const makeSpotifyRequest = async (endpoint, method = 'GET', body = null, roomCode = null) => {
   let apiUrl;


### PR DESCRIPTION
This pull request mainly improves the reliability of Spotify authentication by introducing proper token expiration handling and proactive refresh logic in the backend. It also updates several dependencies in both the backend and frontend, and documents the Spotify fix in the changelog. The most significant changes are grouped below.

**Spotify Token Management Improvements:**
* Added `expiresIn` handling and `expiresAt` tracking when storing Spotify tokens, allowing the backend to know when tokens expire. [[1]](diffhunk://#diff-9333880a62cc36420cb33c30a25df184952bbad97542747adf3054e60e03de6aL39-R45) [[2]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L92-R107)
* Introduced the `ensureValidToken` function to proactively refresh tokens if they are about to expire, and integrated it into all Spotify API flows to prevent authentication errors after 1 hour of play. [[1]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L17-R28) [[2]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L30-R37) [[3]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L53-R60) [[4]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L92-R107) [[5]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L117-R129) [[6]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L146-R158) [[7]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L215-R227) [[8]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L284-R296) [[9]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7L365-R377) [[10]](diffhunk://#diff-93f0d354d5036cd9b551eb88fd94b7cca25c50ee90806cbe9a57e6b7781234f7R463-R481)
* Refactored `refreshAccessTokenIfNeeded` to avoid recursion and ensure safe token refreshes.

**Dependency Updates:**
* Updated backend dependencies: `dotenv` to 17.2.1 and `redis` to 5.7.0 in `backend/package.json`.
* Updated frontend dependencies: `axios`, `react`, `react-dom`, `react-router-dom`, and dev dependencies in `frontend/package.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L14-R19) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L31-R33)

**Documentation:**
* Added a changelog entry for version 2.2.4 to highlight the Spotify token refresh fix.

**Minor Code Cleanup:**
* Removed unused `storeSpotifyToken` function from the frontend Spotify service.