### PR TITLE
chore: fix encoded uri for nicknames to permit special characters

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
-        "redis": "^5.7.0",
+        "redis": "^5.8.0",
         "socket.io": "^4.8.1",
         "spotify-web-api-node": "^5.0.2"
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,9 +28,9 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@vitejs/plugin-react": "^4.7.0",
+        "@vitejs/plugin-react": "^5.0.0",
         "knip": "^5.62.0",
-        "vite": "^7.0.6",
+        "vite": "^7.1.0",
         "vite-plugin-svgr": "^4.3.0"
     }
 }

--- a/frontend/src/components/common/HeaderMenu/HeaderMenu.jsx
+++ b/frontend/src/components/common/HeaderMenu/HeaderMenu.jsx
@@ -41,7 +41,7 @@ function HeaderMenu({ activeRoomCode }) {
           <nav className="desktop-nav">
             <Link className="nav-item" to="/">Accueil</Link>
             {storedRoomCode && storedPseudo && (
-              <Link className="nav-item" to={`/client?roomCode=${storedRoomCode}&pseudo=${storedPseudo}`}>
+              <Link className="nav-item" to={`/client?roomCode=${encodeURIComponent(storedRoomCode)}&pseudo=${encodeURIComponent(storedPseudo)}`}>
                 Ma salle
               </Link>
             )}
@@ -90,7 +90,7 @@ function HeaderMenu({ activeRoomCode }) {
 
               {storedRoomCode && storedPseudo && (
                 <DropdownMenu.Item className="mobile-menu-item">
-                  <Link to={`/client?roomCode=${storedRoomCode}&pseudo=${storedPseudo}`}>
+                  <Link to={`/client?roomCode=${encodeURIComponent(storedRoomCode)}&pseudo=${encodeURIComponent(storedPseudo)}`}>
                     Ma salle
                   </Link>
                 </DropdownMenu.Item>

--- a/frontend/src/pages/Changelog/Changelog.jsx
+++ b/frontend/src/pages/Changelog/Changelog.jsx
@@ -11,6 +11,18 @@ function Changelog() {
   // Données du changelog - vous pouvez les externaliser dans un fichier JSON plus tard
   const changelogEntries = [
     {
+      version: "2.2.5",
+      date: "2025-08-07",
+      type: "patch",
+      title: "Correction problème pseudo",
+      changes: [
+        {
+          type: "fix",
+          text: "Correction qui empêchait les joueurs d'utiliser un pseudo contenant le caractère '&'"
+        }
+      ]
+    },
+    {
       version: "2.2.4",
       date: "2025-08-05",
       type: "patch",

--- a/frontend/src/pages/HomePage/HomePage.jsx
+++ b/frontend/src/pages/HomePage/HomePage.jsx
@@ -175,7 +175,7 @@ function HomePage({ setActiveRoomCode }) {
     setActiveRoomCode(roomCode);
     
     // Rediriger vers la page client
-    navigate(`/client?roomCode=${roomCode}&pseudo=${pseudo}`);
+    navigate(`/client?roomCode=${encodeURIComponent(roomCode)}&pseudo=${encodeURIComponent(pseudo)}`);
   };
   
   // Permettre de revenir dans une salle si les informations sont déjà enregistrées
@@ -208,7 +208,7 @@ function HomePage({ setActiveRoomCode }) {
     
     // La salle existe, on peut continuer
     setActiveRoomCode(savedRoomCode);
-    navigate(`/client?roomCode=${savedRoomCode}&pseudo=${savedPseudo}`);
+    navigate(`/client?roomCode=${encodeURIComponent(savedRoomCode)}&pseudo=${encodeURIComponent(savedPseudo)}`);
   };
 
   // Connexion admin


### PR DESCRIPTION
This pull request addresses an issue where player pseudonyms containing special characters (such as '&') caused problems in navigation links. The main change is to ensure that both the room code and pseudonym are properly URL-encoded whenever they are used in navigation or links, preventing errors and improving user experience. Additionally, a new changelog entry documents this fix.

Bug fix for navigation with special characters:

* All navigation and link generation to the `/client` route now encode `roomCode` and `pseudo` using `encodeURIComponent`, ensuring special characters are handled correctly. This change affects both desktop and mobile navigation in `HeaderMenu.jsx`, and navigation actions in `HomePage.jsx`. [[1]](diffhunk://#diff-bbf28c722c91d82f1f754e42d6780115f24d9d872bb64e476723d7fe59ab7884L44-R44) [[2]](diffhunk://#diff-bbf28c722c91d82f1f754e42d6780115f24d9d872bb64e476723d7fe59ab7884L93-R93) [[3]](diffhunk://#diff-3970da01e8e40e938c2777745a42098c94fcf66dc4dd36cf123124f412861334L178-R178) [[4]](diffhunk://#diff-3970da01e8e40e938c2777745a42098c94fcf66dc4dd36cf123124f412861334L211-R211)

Documentation update:

* Added a new changelog entry for version 2.2.5, describing the fix for the issue with pseudonyms containing the '&' character.